### PR TITLE
Add GitHub workflow to prevent non-develop PRs and update .gitignore

### DIFF
--- a/.github/workflows/block_non_develop_prs.yml
+++ b/.github/workflows/block_non_develop_prs.yml
@@ -1,0 +1,16 @@
+name: 'Block Non-Develop PRs to Main'
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  restrict-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Base and Head
+        if: ${{ github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref != 'develop' }}
+        run: exit 1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-//
+//vs code config
+.vscode/


### PR DESCRIPTION
- Add a new GitHub Actions workflow to block pull requests to branches other than 'develop'.
- Update .gitignore to improve file exclusions.